### PR TITLE
Update transformers.py

### DIFF
--- a/releat/data/transformers.py
+++ b/releat/data/transformers.py
@@ -452,6 +452,7 @@ def get_transform_params_for_one_feature_group(config, feat_group_ind):
                             lambda x: x.take_every(take_every_num).head(obs_len),
                         ),
                     )
+                    .filter(pl.col("group_ind") >= 0)  # Fixed line here
                     .with_columns(pl.lit(df_raw["time_msc"]).alias("time_msc"))
                 )
                 df = df.head(len(df) - int(obs_len * num * mult))
@@ -474,6 +475,7 @@ def get_transform_params_for_one_feature_group(config, feat_group_ind):
             feats = dfs.select(cols).to_numpy()
 
         _ = get_transform_params(config, feat_group_ind, feat_ind, feats)
+
 
 
 def get_transform_params_for_all_features(config):


### PR DESCRIPTION
TypeError: '>=' not supported between instances of 'str' and 'int' on line 455. modification was made on the line with the .filter(pl.col("group_ind") >= 0) operation.